### PR TITLE
Fix: 환경변수 .env로 통일

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,13 +4,14 @@ import boto3, os
 from pymongo import MongoClient
 
 from datetime import datetime
-# DB 환경설정
-client = MongoClient('mongodb+srv://team24:2424@cluster0.ypbmrjf.mongodb.net/Cluster0?retryWrites=true&w=majority')
-db = client.dbsparta
 
 app = Flask(__name__)
 app.config['JSON_AS_ASCII'] = False # UTF-인코딩
 load_dotenv() # 환경변수 불러오기
+
+# DB 환경설정
+client = MongoClient(os.getenv('DB_URL'))
+db = client.dbsparta
 
 # AWS s3 설정
 s3 = boto3.client(


### PR DESCRIPTION
## 주요사항
- 지난 번 PR #5 에서 누락된 DB 환경변수 추가

## 필수 조건
- `.env` 파일 생성 (해당 정보는 credential이기 때문에 전체 내용은 직접 전달 예정 )
```
AWS_BUCKET_NAME = <bucket_name>
AWS_ACCESS_KEY = <access_key>
AWS_SECRET_ACCESS_KEY = <secret_access_key>
AWS_DOMAIN = <domain>

DB_URL = <db_url>
```